### PR TITLE
Design: 전체유저조회 사이드바 레이아웃 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "^16.18.61",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
+        "axios": "^1.6.1",
         "framer-motion": "^10.16.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -7208,6 +7209,29 @@
       "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -17204,6 +17228,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^16.18.61",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
+    "axios": "^1.6.1",
     "framer-motion": "^10.16.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/@types/user.ts
+++ b/src/@types/user.ts
@@ -1,0 +1,5 @@
+export interface User {
+  id: string;
+  name: string;
+  picture: string;
+}

--- a/src/api/useGetUsers.ts
+++ b/src/api/useGetUsers.ts
@@ -1,0 +1,19 @@
+import { User } from '../@types/user';
+import instance from '../constants/appClient';
+
+export const getAllUsers = async () => {
+  try {
+    const response = await instance.get<User[]>('users');
+    const users = response.data;
+
+    const totalUsers = users.length;
+
+    const userNames = users.map((user) => user.name);
+    const profilePictures = users.map((user) => user.picture);
+
+    return { totalUsers, userNames, profilePictures };
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/components/AllUserBar/index.tsx
+++ b/src/components/AllUserBar/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Avatar,
   AvatarBadge,
@@ -8,35 +8,40 @@ import {
   Stack,
   Text,
 } from '@chakra-ui/react';
+import { useUserData } from '../../hooks/useUserData';
 
 const allUserBar = () => {
+  const userData = useUserData();
+
   return (
     <Box flex="1">
       <Flex>
         <Box flex="3"></Box>
-        <Stack direction="row" h="100vh" color="{white}">
-          <Divider mt={3} orientation="vertical" borderColor={'gray.400'} />
+        <Stack direction="row" h="100vh">
+          <Divider mt="12" orientation="vertical" borderColor={'gray.400'} />
         </Stack>
-        <Box flex="1" w="280px" h="100vh" bg="gray.50" p={30}>
-          <Text fontSize="1g" fontWeight="normal" color="gray.400" mt={10}>
-            전체ㅡ 숫자
+        <Box flex="1" w="280px" h="100vh" bg="gray.50" p="6">
+          <Text fontSize="1g" fontWeight="normal" color="gray.400" mt="8">
+            전체ㅡ {userData.totalUsers}
           </Text>
-          <Divider mt={3} borderColor={'gray.500'} />
-          <Flex mt={5}>
-            <Stack direction="column" spacing={4}>
-              <Avatar
-                size="sm"
-                name="Kent Dodds"
-                src="https://bit.ly/kent-c-dodds"
-              >
-                <AvatarBadge boxSize="1.25em" bg="green.500" />
-              </Avatar>
+          <Divider mt="4" borderColor={'gray.500'} />
+          <Flex mt="4" align="center">
+            <Stack direction="column" spacing="0">
+              {userData.userNames.map((userName, index) => (
+                <Flex key={index} mt="4">
+                  <Avatar
+                    size="sm"
+                    name={userName}
+                    src={userData.profilePictures[index]}
+                  >
+                    <AvatarBadge boxSize="1.25em" bg="green.500" />
+                  </Avatar>
+                  <Text fontSize="sm" color="black" ml="3" mt="1">
+                    {userName}
+                  </Text>
+                </Flex>
+              ))}
             </Stack>
-            <Flex align="center" justify="center">
-              <Text fontSize="sm" color="black" ml={3}>
-                새콤달콤
-              </Text>
-            </Flex>
           </Flex>
         </Box>
       </Flex>

--- a/src/components/AllUserBar/index.tsx
+++ b/src/components/AllUserBar/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+  Avatar,
+  AvatarBadge,
+  Box,
+  Divider,
+  Flex,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
+
+const allUserBar = () => {
+  return (
+    <Box flex="1">
+      <Flex>
+        <Box flex="3"></Box>
+        <Stack direction="row" h="100vh" color="{white}">
+          <Divider mt={3} orientation="vertical" borderColor={'gray.400'} />
+        </Stack>
+        <Box flex="1" w="280px" h="100vh" bg="gray.50" p={30}>
+          <Text fontSize="1g" fontWeight="normal" color="gray.400" mt={10}>
+            전체ㅡ 숫자
+          </Text>
+          <Divider mt={3} borderColor={'gray.500'} />
+          <Flex mt={5}>
+            <Stack direction="column" spacing={4}>
+              <Avatar
+                size="sm"
+                name="Kent Dodds"
+                src="https://bit.ly/kent-c-dodds"
+              >
+                <AvatarBadge boxSize="1.25em" bg="green.500" />
+              </Avatar>
+            </Stack>
+            <Flex align="center" justify="center">
+              <Text fontSize="sm" color="black" ml={3}>
+                새콤달콤
+              </Text>
+            </Flex>
+          </Flex>
+        </Box>
+      </Flex>
+    </Box>
+  );
+};
+
+export default allUserBar;

--- a/src/constants/apiUrl.ts
+++ b/src/constants/apiUrl.ts
@@ -1,0 +1,1 @@
+export const API_BASED_URL = process.env.REACT_APP_API_URL;

--- a/src/constants/appClient.ts
+++ b/src/constants/appClient.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+import { API_BASED_URL } from './apiUrl';
+
+const instance = axios.create({
+  baseURL: `${API_BASED_URL}`,
+  headers: {
+    'content-Type': 'application/json',
+    Authorization: `Bearer ${process.env.REACT_APP_USER_TOKEN || ''}`,
+    serverId: `${process.env.REACT_APP_SERVER_ID}`,
+  },
+});
+
+export default instance;

--- a/src/hooks/useUserData.ts
+++ b/src/hooks/useUserData.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import { getAllUsers } from '../api/useGetUsers';
+
+export const useUserData = () => {
+  const [userData, setUserData] = useState<{
+    totalUsers: number;
+    userNames: string[];
+    profilePictures: string[];
+  }>({
+    totalUsers: 0,
+    userNames: [],
+    profilePictures: [],
+  });
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        const usersData = await getAllUsers();
+        setUserData(usersData);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    fetchUserData();
+  }, []);
+
+  return userData;
+};


### PR DESCRIPTION
## ⛳️개요
전체 채팅 조회 페이지에만 존재하는 전체 유저 조회 사이드바 레이아웃 구현입니다.
커스텀 훅을 따로 만들어 두긴 했으나, 전체 유저 수 등 필요하지 않은 부분을 불러올 수도 있는 부분이 있습니다.
npm i axios 했습니다 !


## 📸 스크린샷
![KakaoTalk_20231110_100511355](https://github.com/Chatting-App-FE/Chatting-App-FE/assets/38286505/80aa461d-cefa-4386-9091-c71787d109b5)


## ✍️ 구현 사항

- [x] charkr ui를 사용하여 layout 구현하였습니다.
- [x] axios를 통해 전체 유저 정보를 불러올 수 있습니다.

## ⚡️ 고민한 점 질문거리
chakra ui를 처음 사용해보게 되어서, 은영님과 가현님 pr을 참고도 하고, 레퍼런스를 찾아가면서 구현해봤습니다.
조금 더 익숙해지면 잘 사용할 수 있을 것 같아요.

++
커스텀 훅을 따로 두긴 했으나, 필요하신 정보만을 가져오지 않는 훅일 수도 있을 것 같아서 어떠면 좋을지 알려주세요!!
ex) 저는 전체 유저 수 + 프로필 명+  사진만을 갖고와 사용하게끔 api를 작성해둔거라, 이 부분을 수정하는게 좋을까요? 아니면, 
따로 갖고와서 쓰지 않는 방법도 괜찮을까요?
아님, 다시 만드는게 좋을까요. 이 부분이 고민입니다.