### PR TITLE
Feat: 전체 채팅 목록 카테고리 기능 구현 & 드래그 슬라이드 구현

### DIFF
--- a/src/components/AllUserBar/index.tsx
+++ b/src/components/AllUserBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
   Avatar,
   AvatarBadge,
@@ -10,7 +10,7 @@ import {
 } from '@chakra-ui/react';
 import { useUserData } from '../../hooks/useUserData';
 
-const allUserBar = () => {
+const AllUserBar = () => {
   const userData = useUserData();
 
   return (
@@ -49,4 +49,4 @@ const allUserBar = () => {
   );
 };
 
-export default allUserBar;
+export default AllUserBar;

--- a/src/components/channel/ChannelRadio.tsx
+++ b/src/components/channel/ChannelRadio.tsx
@@ -1,0 +1,54 @@
+import { Box, useRadio } from '@chakra-ui/react';
+import React, { ChangeEvent, useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { channelState } from '../../recoil/channel.atom';
+
+const ChannelRadio = (props: any) => {
+  const { getInputProps, getRadioProps } = useRadio(props);
+  const [categoryChannel, setCategoryChannel] = useRecoilState(channelState);
+
+  const input = getInputProps({
+    onChange: (e: ChangeEvent<HTMLInputElement>) => {
+      setCategoryChannel({ ...categoryChannel, category: e.target.value });
+    },
+  });
+  const checkbox = getRadioProps();
+
+  useEffect(() => {
+    // categoryChannel이 변경되면 onSelectCategory 호출
+    props.onSelectCategory(categoryChannel.category);
+  }, [categoryChannel]);
+
+  return (
+    <>
+      <Box as="label">
+        <input
+          {...input}
+          onClick={() => props.onSelectCategory(categoryChannel.category)}
+        />
+        <Box
+          {...checkbox}
+          cursor="pointer"
+          borderWidth="1px"
+          borderRadius="md"
+          boxShadow="md"
+          color="black"
+          _checked={{
+            bg: props.customColor, // 커스텀 컬러 지정
+            color: 'white',
+            borderColor: props.customColor, // 커스텀 컬러 지정
+          }}
+          fontSize="xs"
+          px="3"
+          py="1"
+          whiteSpace="nowrap"
+          userSelect="none"
+        >
+          {props.children}
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+export default ChannelRadio;

--- a/src/components/channel/ChannelSelector.tsx
+++ b/src/components/channel/ChannelSelector.tsx
@@ -1,0 +1,58 @@
+import { Box, Flex, HStack, useRadioGroup } from '@chakra-ui/react';
+import React from 'react';
+import { CATEGORIES, CATEGORY_COLOR_SCHEMES } from '../../constants/channel';
+import ChannelRadio from './ChannelRadio';
+import ScrollContainer from 'react-indiana-drag-scroll';
+
+const ChannelSelector = ({ onSelectCategory }: any) => {
+  const options = CATEGORIES;
+
+  const { getRootProps, getRadioProps } = useRadioGroup({
+    name: 'Category',
+    defaultValue: '전체',
+  });
+
+  const group = getRootProps();
+
+  return (
+    <>
+      <Flex>
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignContent="center"
+          bg="#F4F4F4"
+          w={920}
+          mt="4"
+          mb="4"
+          color="black"
+          border="1px solid #cbcbcb"
+          borderRadius="4"
+          boxShadow="md"
+          p="4"
+          overflow="auto"
+        >
+          <ScrollContainer className="scroll-container">
+            <HStack {...group} align="center" spacing={4} mb="1">
+              {options.map((value) => {
+                const radio = getRadioProps({ value });
+                return (
+                  <ChannelRadio
+                    key={value}
+                    {...radio}
+                    customColor={CATEGORY_COLOR_SCHEMES[value]}
+                    onSelectCategory={onSelectCategory}
+                  >
+                    {value}
+                  </ChannelRadio>
+                );
+              })}
+            </HStack>
+          </ScrollContainer>
+        </Box>
+      </Flex>
+    </>
+  );
+};
+
+export default ChannelSelector;

--- a/src/components/channel/index.tsx
+++ b/src/components/channel/index.tsx
@@ -1,20 +1,46 @@
+import React, { useState, useEffect } from 'react';
 import { Box, HStack } from '@chakra-ui/react';
 import useChannels from '../../hooks/useChannels';
 import ChannelCard from './ChannelCard';
+import ChannelSelector from './ChannelSelector';
+import { splitChannelName } from '../../utils';
 
 const ChannelList = () => {
   const { data: channels, isLoading } = useChannels();
+  const [selectedCategory, setSelectedCategory] = useState<string>('전체');
+
+  const handleCategoryChange = (category: string) => {
+    setSelectedCategory(category);
+  };
+
+  useEffect(() => {
+    console.log(selectedCategory);
+    handleCategoryChange(selectedCategory);
+    // 여기에서 상태값이 변경된 후 수행할 작업을 추가할 수 있습니다.
+  }, [selectedCategory]);
 
   if (isLoading) return <div>Loading...</div>;
 
   if (channels && channels.length === 0) return <div>채팅방이 없습니다.</div>;
 
+  const filteredChannels =
+    selectedCategory === '전체'
+      ? channels
+      : channels?.filter((channel) => {
+          const { category } = splitChannelName(channel.name);
+          return category === selectedCategory;
+        });
+
   return (
     <>
       <Box>
+        <ChannelSelector onSelectCategory={handleCategoryChange} />
+        <div>{selectedCategory}</div>
+      </Box>
+      <Box>
         <HStack gap="4" flexWrap="wrap">
-          {channels &&
-            channels.map((channel) => (
+          {filteredChannels &&
+            filteredChannels.map((channel) => (
               <ChannelCard key={channel.id} channel={channel} />
             ))}
         </HStack>

--- a/src/constants/channel.ts
+++ b/src/constants/channel.ts
@@ -1,6 +1,7 @@
 export const ALL_CHANNELS = ['channels'];
 
 export const CATEGORIES = [
+  '전체',
   '기타',
   '일상',
   '프로그래밍',
@@ -9,9 +10,11 @@ export const CATEGORIES = [
   '프론트엔드',
   '백엔드',
   '알고리즘',
+  '산책',
 ];
 
 export const CATEGORY_COLOR_SCHEMES: { [key: string]: string } = {
+  전체: 'skyblue',
   기타: 'red',
   일상: 'orange',
   프로그래밍: 'yellow',
@@ -20,4 +23,5 @@ export const CATEGORY_COLOR_SCHEMES: { [key: string]: string } = {
   프론트엔드: 'indigo',
   백엔드: 'purple',
   알고리즘: 'pink',
+  산책: 'gray',
 };


### PR DESCRIPTION
## ⛳️개요
- 전체 채팅 목록에서 Chakra ui radio를 활용한 태그 기능 및 선택된 값에 따른 카테고리에 해당되는 채팅방 필터링 (렌더링) 구현

- Radio를 감싼 Box에서 drag를 통한 슬라이드 기능 추가

- react-indiana-drag-scroll 라이브러리 사용 
- ※ npm install --save react-indiana-drag-scroll ※ 해주셔야 합니다!

## 📸 스크린샷

https://github.com/Chatting-App-FE/Chatting-App-FE/assets/38286505/3fa726d8-a93b-430e-8963-8c2bef6f5060


## ✍️ 구현 사항

- [ ] 첫 전체 채팅 페이지에 들어가면 전체 태그로 선택되어 전체 리스트 렌더링 및 선택된 카테고리에 따른 조건부 렌더링
- [ ] react-indiana-drag-scroll 라이브러리를 사용해 radiogroup으로 구현된 리스트들이 정해진 Box width보다 많아지면, 드래그를 통한 슬라이드 기능 구현
(이 부분은, 아직 더 많은 카테고리가 있지 않아서, 위의 영상에서는 의도적으로 추가하여 영상 찍었어요!)
- [ ]

## ⚡️ 고민한 점 질문거리
- 모달 창 내에서는 추후 개발할 것 같아요 ! 
- 사실 코드가 그렇게 깔끔하진 않아서 리팩토링할 부분은 할 예정이고, 피드백 주시면 감사하겠습니다 ! !
- 한가지 더, 전체 태그를 클릭할 경우와 나머지 태그를 클릭할 경우 size가 약간 달라지는 부분이 보이는데, 이 부분 찾아보고 적용하겠습니다 !

- Swiper 및, Slide 등 다양한 라이브러리를 사용해봤지만, 원하는 결과가 제대로 나오지 않아서 가장 기대한 결과와 비슷한 라이브러리를 사용했습니다. 
- 직접 슬라이드 기능을 구현해보기도 하였지만, 생각보다 매끄럽게 만들어지지 않아서 바꿨어요 . . 

