### PR TITLE
Fix: 유저목록에서 온라인 유저 표시 기능 일시 삭제 및 수정

### DIFF
--- a/src/@types/user.ts
+++ b/src/@types/user.ts
@@ -10,3 +10,8 @@ export interface User2 {
   username?: string;
   picture: string;
 }
+
+export interface AuthResponseValue {
+  auth: boolean;
+  user?: User;
+}

--- a/src/api/serverSocket.ts
+++ b/src/api/serverSocket.ts
@@ -2,10 +2,10 @@ import { io } from 'socket.io-client';
 
 const chatId = 'fb4de663-7142-4924-b7b2-9159bf2d8a31';
 
-const socket = io(`${process.env.REACT_APP_API_URL}/chat?chatId=${chatId}`, {
+const serverSocket = io(`${process.env.REACT_APP_API_URL}/server`, {
   extraHeaders: {
     Authorization: `Bearer ${process.env.REACT_APP_USER_TOKEN}`,
     serverId: `${process.env.REACT_APP_SERVER_ID}`,
   },
 });
-export default socket;
+export default serverSocket;

--- a/src/api/serverSocket.ts
+++ b/src/api/serverSocket.ts
@@ -1,7 +1,5 @@
 import { io } from 'socket.io-client';
 
-const chatId = 'fb4de663-7142-4924-b7b2-9159bf2d8a31';
-
 const serverSocket = io(`${process.env.REACT_APP_API_URL}/server`, {
   extraHeaders: {
     Authorization: `Bearer ${process.env.REACT_APP_USER_TOKEN}`,

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,4 +1,4 @@
-import { User } from '../@types/user';
+import { AuthResponseValue, User } from '../@types/user';
 import instance from './axios';
 
 export const getUser = async (userId: string) => {
@@ -34,6 +34,18 @@ export const getUsers = async () => {
   try {
     const response = await instance.get<User[]>('/users');
     return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export const getAuthUser = async () => {
+  try {
+    const response = await instance.get<AuthResponseValue>('/users');
+    const authUserId = response.data.user?.id;
+
+    return authUserId;
   } catch (error) {
     console.error(error);
     throw error;

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -34,7 +34,7 @@ export const getUsers = async () => {
 
 export const getAuthUser = async () => {
   try {
-    const response = await instance.get<AuthResponseValue>('/users');
+    const response = await instance.get<AuthResponseValue>('/auth/me');
     const authUserId = response.data.user?.id;
 
     return authUserId;

--- a/src/components/channel/modal/CategoryRadio.tsx
+++ b/src/components/channel/modal/CategoryRadio.tsx
@@ -9,7 +9,6 @@ const CategoryRadio = (props: ReturnType<typeof getRadioProps>) => {
 
   const input = getInputProps({
     onChange: (e: ChangeEvent<HTMLInputElement>) => {
-      console.log(e.target.value, channel.category);
       setChannel({ ...channel, category: e.target.value });
     },
   });

--- a/src/components/channelMemberSideBar/ChannelMemberItem.tsx
+++ b/src/components/channelMemberSideBar/ChannelMemberItem.tsx
@@ -4,15 +4,12 @@ import { Avatar, AvatarBadge, Flex, Text } from '@chakra-ui/react';
 interface MemberItemProps {
   userName?: string;
   src?: string;
-  isOnline?: boolean;
 }
 
 const ChannelMemberItem = ({ userName, src }: MemberItemProps) => {
   return (
     <Flex mt="2" align="center">
-      <Avatar size="md" name={userName} src={src}>
-        <AvatarBadge boxSize="1.25em" bg="green.500" />
-      </Avatar>
+      <Avatar size="md" name={userName} src={src}></Avatar>
       <Text fontSize="lg" color="black" ml="3" mt="1">
         {userName}
       </Text>

--- a/src/components/channelMemberSideBar/ChannelMemberItem.tsx
+++ b/src/components/channelMemberSideBar/ChannelMemberItem.tsx
@@ -4,21 +4,16 @@ import { Avatar, AvatarBadge, Flex, Text } from '@chakra-ui/react';
 interface MemberItemProps {
   userName?: string;
   src?: string;
-  isOnline: boolean;
+  isOnline?: boolean;
 }
 
-const ChannelMemberItem = ({ userName, src, isOnline }: MemberItemProps) => {
+const ChannelMemberItem = ({ userName, src }: MemberItemProps) => {
   return (
     <Flex mt="2" align="center">
-      <Avatar
-        size="md"
-        name={userName}
-        src={src}
-        filter={isOnline ? 'none' : 'grayscale(90%)'}
-      >
+      <Avatar size="md" name={userName} src={src}>
         <AvatarBadge boxSize="1.25em" bg="green.500" />
       </Avatar>
-      <Text fontSize="lg" color={isOnline ? 'black' : 'gray.300'} ml="3" mt="1">
+      <Text fontSize="lg" color="black" ml="3" mt="1">
         {userName}
       </Text>
     </Flex>

--- a/src/components/channelMemberSideBar/index.tsx
+++ b/src/components/channelMemberSideBar/index.tsx
@@ -37,7 +37,6 @@ const ChannelMemberSideBar = () => {
             key={user.id}
             userName={user.name || user.username}
             src={user.picture}
-            isOnline={onlineUserIds.includes(user.id)}
           />
         ))}
       </VStack>

--- a/src/components/channelMemberSideBar/index.tsx
+++ b/src/components/channelMemberSideBar/index.tsx
@@ -10,7 +10,7 @@ const ChannelMemberSideBar = () => {
   const { id } = useParams();
   const chatId = id!;
 
-  const { userList, onlineUserIds, setUserList } = useJoinLeaveChannels(chatId);
+  const { userList, setUserList } = useJoinLeaveChannels(chatId);
 
   return (
     <Box

--- a/src/components/channelMemberSideBar/index.tsx
+++ b/src/components/channelMemberSideBar/index.tsx
@@ -23,7 +23,11 @@ const ChannelMemberSideBar = () => {
     >
       <Flex align="center" mt="10" justifyContent="space-between">
         <Box fontSize="1g"> 채팅 참여 목록 {userList.length}</Box>
-        <UserInviteModal setUserList={setUserList} chatId={chatId} />
+        <UserInviteModal
+          userList={userList}
+          setUserList={setUserList}
+          chatId={chatId}
+        />
       </Flex>
       <Divider mt="1rem" borderColor={'gray.500'} />
 

--- a/src/components/channelMemberSideBar/modal/UserInviteList.tsx
+++ b/src/components/channelMemberSideBar/modal/UserInviteList.tsx
@@ -1,0 +1,61 @@
+import { Center, Flex, Text } from '@chakra-ui/react';
+import { useUsers } from '../../../hooks/useUsers';
+import { useEffect } from 'react';
+import ChannelModalUser from '../../channel/modal/ChannelModalUser';
+import { User2 } from '../../../@types/user';
+
+interface Props {
+  setUsers: React.Dispatch<React.SetStateAction<string[]>>;
+  userList: User2[];
+}
+
+const UserInviteList = ({ setUsers, userList }: Props) => {
+  const { data: users, isLoading, addUser, userSet } = useUsers();
+
+  useEffect(() => {
+    setUsers(Array.from(userSet));
+  }, [userSet]);
+
+  const isIncluded = (id: string) => {
+    return userSet.has(id);
+  };
+
+  const inviteUsers = users?.filter(
+    (user) => !userList.some((u) => u.id === user.id),
+  );
+
+  const ModalUserItem = () => {
+    if (isLoading) {
+      return <Center>로딩중...</Center>;
+    }
+    if (inviteUsers?.length === 0) {
+      return <Center>현재 모든 유저가 채팅방 안에 있습니다.</Center>;
+    }
+    return inviteUsers?.map((user) => (
+      <ChannelModalUser
+        key={user.id}
+        user={user}
+        addUser={addUser}
+        isIncluded={isIncluded}
+      />
+    ));
+  };
+
+  return (
+    <>
+      <Flex mt="4" mb="1" gap="2" alignItems="center">
+        <Text as="h3" fontWeight="bold">
+          친구 초대
+        </Text>
+        <Text fontSize="sm" fontWeight="semibold">
+          {userSet.size}
+        </Text>
+      </Flex>
+      <Flex flexDir="column" gap="2" h={300} overflow="auto">
+        <>{ModalUserItem()}</>
+      </Flex>
+    </>
+  );
+};
+
+export default UserInviteList;

--- a/src/components/channelMemberSideBar/modal/UserInviteModal.tsx
+++ b/src/components/channelMemberSideBar/modal/UserInviteModal.tsx
@@ -13,15 +13,16 @@ import {
 } from '@chakra-ui/react';
 import { AddIcon } from '@chakra-ui/icons';
 import { inviteChannel } from '../../../api/channel';
-import ChannelModalUserList from '../../channel/modal/ChannelModalUserList';
 import { User2 } from '../../../@types/user';
+import UserInviteList from './UserInviteList';
 
 interface Props {
   setUserList: React.Dispatch<React.SetStateAction<User2[]>>;
+  userList: User2[];
   chatId: string;
 }
 
-const UserInviteModal = ({ setUserList, chatId }: Props) => {
+const UserInviteModal = ({ setUserList, userList, chatId }: Props) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [users, setUsers] = useState<string[]>([]);
   const btnRef = useRef(null);
@@ -56,7 +57,7 @@ const UserInviteModal = ({ setUserList, chatId }: Props) => {
             <ModalCloseButton />
 
             <ModalBody>
-              <ChannelModalUserList setUsers={setUsers} />
+              <UserInviteList setUsers={setUsers} userList={userList} />
             </ModalBody>
 
             <ModalFooter justifyContent="center">

--- a/src/components/sideBar/index.tsx
+++ b/src/components/sideBar/index.tsx
@@ -22,7 +22,15 @@ const SideBar = () => {
   useJoinLeaveChannels(chatId);
 
   return (
-    <Box w="18rem" h="100vh" bg="gray.50" color="black" p="20px" boxShadow="xl">
+    <Box
+      w="18rem"
+      position="sticky"
+      h="100vh"
+      bg="gray.50"
+      color="black"
+      p="20px"
+      boxShadow="xl"
+    >
       <Heading my="2rem">로고자리</Heading>
       <Box color="#828C98">
         <ChakraLink as={ReactRouterLink} to="/" fontSize={'lg'}>

--- a/src/components/sideBar/index.tsx
+++ b/src/components/sideBar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link as ReactRouterLink } from 'react-router-dom';
+import { Link as ReactRouterLink, useParams } from 'react-router-dom';
 import {
   Box,
   Text,
@@ -11,10 +11,15 @@ import { EditIcon, ChatIcon } from '@chakra-ui/icons';
 import MyChannelItem from './MyChannelItem';
 import { useMyChannels } from '../../hooks/useMyChannels';
 import { useInviteData } from '../../hooks/useInviteData';
+import useJoinLeaveChannels from '../../hooks/useJoinLeaveChannel';
 
 const SideBar = () => {
   const { data: channels } = useMyChannels();
+  const { id } = useParams();
+  const chatId = id!;
+
   useInviteData();
+  useJoinLeaveChannels(chatId);
 
   return (
     <Box w="18rem" h="100vh" bg="gray.50" color="black" p="20px" boxShadow="xl">

--- a/src/components/sideBar/index.tsx
+++ b/src/components/sideBar/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import {
   Box,

--- a/src/components/sideBar/index.tsx
+++ b/src/components/sideBar/index.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import { Link as ReactRouterLink, useParams } from 'react-router-dom';
+import { Link as ReactRouterLink } from 'react-router-dom';
 import {
   Box,
   Text,
@@ -11,15 +10,10 @@ import { EditIcon, ChatIcon } from '@chakra-ui/icons';
 import MyChannelItem from './MyChannelItem';
 import { useMyChannels } from '../../hooks/useMyChannels';
 import { useInviteData } from '../../hooks/useInviteData';
-import useJoinLeaveChannels from '../../hooks/useJoinLeaveChannel';
 
 const SideBar = () => {
   const { data: channels } = useMyChannels();
-  const { id } = useParams();
-  const chatId = id!;
-
   useInviteData();
-  useJoinLeaveChannels(chatId);
 
   return (
     <Box w="18rem" h="100vh" bg="gray.50" color="black" p="20px" boxShadow="xl">

--- a/src/components/sideBar/index.tsx
+++ b/src/components/sideBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import {
   Box,
@@ -10,9 +10,11 @@ import {
 import { EditIcon, ChatIcon } from '@chakra-ui/icons';
 import MyChannelItem from './MyChannelItem';
 import { useMyChannels } from '../../hooks/useMyChannels';
+import { useInviteData } from '../../hooks/useInviteData';
 
 const SideBar = () => {
   const { data: channels } = useMyChannels();
+  useInviteData();
 
   return (
     <Box w="18rem" h="100vh" bg="gray.50" color="black" p="20px" boxShadow="xl">

--- a/src/constants/channel.ts
+++ b/src/constants/channel.ts
@@ -1,4 +1,5 @@
 export const ALL_CHANNELS = ['channels'];
+export const MY_CHANNELS = ['my-channels'];
 
 export const CATEGORIES = [
   '기타',

--- a/src/constants/socket.ts
+++ b/src/constants/socket.ts
@@ -10,4 +10,7 @@ export const SOCKET = {
   JOIN: 'join',
   USERS: 'users',
   USER_TO_CLIENT: 'users-to-client',
+  USERS_SERVER: 'users-server',
+  USERS_SERVER_TO_CLIENT: 'users-server-to-client',
+  INVITE: 'invite',
 } as const;

--- a/src/hooks/useChannels.ts
+++ b/src/hooks/useChannels.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Channel } from '../@types/channel';
 import { createChannel, getChannels } from '../api/channel';
-import { ALL_CHANNELS } from '../constants/channel';
+import { ALL_CHANNELS, MY_CHANNELS } from '../constants/channel';
 
 export const useChannels = () => {
   return useQuery<Channel[]>({
@@ -19,6 +19,7 @@ export const useCreateChannel = () => {
     mutationFn: createChannel,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ALL_CHANNELS });
+      queryClient.invalidateQueries({ queryKey: MY_CHANNELS });
     },
   });
 };

--- a/src/hooks/useInviteData.ts
+++ b/src/hooks/useInviteData.ts
@@ -4,6 +4,7 @@ import { getMyChannels } from '../api/channel';
 import { ToastId, useToast } from '@chakra-ui/react';
 import { splitChannelName } from '../utils';
 import { SOCKET } from '../constants/socket';
+import { getAuthUser } from '../api/user';
 
 interface InviteResponseData {
   responseChat: {
@@ -25,15 +26,18 @@ export const useInviteData = () => {
   };
 
   useEffect(() => {
-    serverSocket.on(SOCKET.INVITE, (messages: InviteResponseData) => {
+    serverSocket.on(SOCKET.INVITE, async (messages: InviteResponseData) => {
       if (!messages) return;
       const chatName = fetchInviteChannelName(messages.responseChat.name);
-      console.log('chatName', chatName);
-      getMyChannels();
+      const userId = messages.responseChat.users;
+      const authId = await getAuthUser();
+      const invitedUserId = userId.filter((id) => authId == id);
+      console.log('초대되었지롱', invitedUserId);
       toastIdRef.current = toast({
         description: `${chatName} 방에 초대되었습니다.내 채팅방에서 확인해보세요!`,
       });
     });
+
     return () => {
       serverSocket.off(SOCKET.INVITE);
     };

--- a/src/hooks/useInviteData.ts
+++ b/src/hooks/useInviteData.ts
@@ -1,0 +1,41 @@
+import React, { useEffect, useState, useRef } from 'react';
+import serverSocket from '../api/serverSocket';
+import { getMyChannels } from '../api/channel';
+import { ToastId, useToast } from '@chakra-ui/react';
+import { splitChannelName } from '../utils';
+import { SOCKET } from '../constants/socket';
+
+interface InviteResponseData {
+  responseChat: {
+    id: string;
+    name: string;
+    users: string[]; // 참여자들 id
+    isPrivate: boolean;
+    updatedAt: Date;
+  };
+}
+
+export const useInviteData = () => {
+  const [inviteAlertData, setInviteAlertData] = useState<InviteResponseData>();
+  const toast = useToast();
+  const toastIdRef = useRef<ToastId>();
+
+  const fetchInviteChannelName = (name: string) => {
+    const { title, category } = splitChannelName(name);
+    return title;
+  };
+
+  useEffect(() => {
+    serverSocket.on(SOCKET.INVITE, (messages: InviteResponseData) => {
+      if (!messages) return;
+      const chatName = fetchInviteChannelName(messages.responseChat.name);
+      console.log('chatName', chatName);
+      toastIdRef.current = toast({
+        description: `${chatName} 방에 초대되었습니다. 내 채팅방 목록에서 확인해보세요!`,
+      });
+    });
+    return () => {
+      serverSocket.off(SOCKET.INVITE);
+    };
+  }, []);
+};

--- a/src/hooks/useInviteData.ts
+++ b/src/hooks/useInviteData.ts
@@ -32,7 +32,6 @@ export const useInviteData = () => {
       const userId = messages.responseChat.users;
       const authId = await getAuthUser();
       const invitedUserId = userId.filter((id) => authId == id);
-      console.log('초대되었지롱', invitedUserId);
       toastIdRef.current = toast({
         description: `${chatName} 방에 초대되었습니다.내 채팅방에서 확인해보세요!`,
       });

--- a/src/hooks/useInviteData.ts
+++ b/src/hooks/useInviteData.ts
@@ -16,12 +16,11 @@ interface InviteResponseData {
 }
 
 export const useInviteData = () => {
-  const [inviteAlertData, setInviteAlertData] = useState<InviteResponseData>();
   const toast = useToast();
   const toastIdRef = useRef<ToastId>();
 
   const fetchInviteChannelName = (name: string) => {
-    const { title, category } = splitChannelName(name);
+    const { title } = splitChannelName(name);
     return title;
   };
 
@@ -30,8 +29,9 @@ export const useInviteData = () => {
       if (!messages) return;
       const chatName = fetchInviteChannelName(messages.responseChat.name);
       console.log('chatName', chatName);
+      getMyChannels();
       toastIdRef.current = toast({
-        description: `${chatName} 방에 초대되었습니다. 내 채팅방 목록에서 확인해보세요!`,
+        description: `${chatName} 방에 초대되었습니다.내 채팅방에서 확인해보세요!`,
       });
     });
     return () => {

--- a/src/hooks/useJoinLeaveChannel.ts
+++ b/src/hooks/useJoinLeaveChannel.ts
@@ -20,7 +20,6 @@ export const useJoinLeaveChannels = (chatId: string) => {
       SOCKET.LEAVE,
       async (messages: { users: string[]; joiners: string[] }) => {
         const newMemberList = await getMemberData(messages.users);
-        console.log('LEAVE', messages);
         setUserList(newMemberList);
       },
     );
@@ -28,7 +27,6 @@ export const useJoinLeaveChannels = (chatId: string) => {
       SOCKET.JOIN,
       async (messages: { users: string[]; joiners: string[] }) => {
         const newMemberList = await getMemberData(messages.users);
-        console.log('JOIN', messages);
         setUserList(newMemberList);
       },
     );

--- a/src/hooks/useJoinLeaveChannel.ts
+++ b/src/hooks/useJoinLeaveChannel.ts
@@ -3,11 +3,9 @@ import socket from '../api/socket';
 import { User2 } from '../@types/user';
 import { SOCKET } from '../constants/socket';
 import { getMemberData, findUserDataInChannel } from '../api/channel';
-import serverSocket from '../api/serverSocket';
 
 export const useJoinLeaveChannels = (chatId: string) => {
   const [userList, setUserList] = useState<User2[]>([]);
-  const [onlineUserIds, setOnlineUsersIds] = useState<string[]>([]);
 
   useEffect(() => {
     const getAllMemberList = async () => {
@@ -17,19 +15,11 @@ export const useJoinLeaveChannels = (chatId: string) => {
     };
     getAllMemberList();
 
-    serverSocket.emit(SOCKET.USERS_SERVER);
-    serverSocket.on(
-      SOCKET.USERS_SERVER_TO_CLIENT,
-      (messages: { users: string[] }) => {
-        if (!messages) return;
-        setOnlineUsersIds(messages.users);
-      },
-    );
-
     socket.on(
       SOCKET.LEAVE,
       async (messages: { users: string[]; joiners: string[] }) => {
         const newMemberList = await getMemberData(messages.users);
+        console.log('LEAVE', messages);
         setUserList(newMemberList);
       },
     );
@@ -37,6 +27,7 @@ export const useJoinLeaveChannels = (chatId: string) => {
       SOCKET.JOIN,
       async (messages: { users: string[]; joiners: string[] }) => {
         const newMemberList = await getMemberData(messages.users);
+        console.log('JOIN', messages);
         setUserList(newMemberList);
       },
     );
@@ -44,11 +35,10 @@ export const useJoinLeaveChannels = (chatId: string) => {
     return () => {
       socket.off(SOCKET.JOIN);
       socket.off(SOCKET.LEAVE);
-      serverSocket.off(SOCKET.USERS_SERVER_TO_CLIENT);
     };
   }, [chatId]);
 
-  return { userList, onlineUserIds, setUserList };
+  return { userList, setUserList };
 };
 
 export default useJoinLeaveChannels;

--- a/src/hooks/useJoinLeaveChannel.ts
+++ b/src/hooks/useJoinLeaveChannel.ts
@@ -3,6 +3,7 @@ import socket from '../api/socket';
 import { User2 } from '../@types/user';
 import { SOCKET } from '../constants/socket';
 import { getMemberData, findUserDataInChannel } from '../api/channel';
+import serverSocket from '../api/serverSocket';
 
 export const useJoinLeaveChannels = (chatId: string) => {
   const [userList, setUserList] = useState<User2[]>([]);
@@ -19,8 +20,19 @@ export const useJoinLeaveChannels = (chatId: string) => {
     socket.emit(SOCKET.USERS);
     socket.on(SOCKET.USER_TO_CLIENT, (messages: { users: string[] }) => {
       if (!messages) return;
-      setOnlineUsersIds(messages.users);
+      //setOnlineUsersIds(messages.users);
+      console.log('USER_TO_CLIENT', messages); // 현재방의 실시간유저, 방 랜더링 안되니까 당연히 안바뀜
     });
+
+    serverSocket.emit(SOCKET.USERS_SERVER);
+    serverSocket.on(
+      SOCKET.USERS_SERVER_TO_CLIENT,
+      (messages: { users: string[] }) => {
+        if (!messages) return;
+        setOnlineUsersIds(messages.users);
+        console.log('users-server-to-client', messages);
+      },
+    );
 
     socket.on(
       SOCKET.LEAVE,
@@ -32,7 +44,7 @@ export const useJoinLeaveChannels = (chatId: string) => {
 
     return () => {
       socket.off(SOCKET.LEAVE);
-      socket.off(SOCKET.USER_TO_CLIENT);
+      serverSocket.off(SOCKET.USERS_SERVER_TO_CLIENT);
     };
   }, [chatId]);
 

--- a/src/hooks/useJoinLeaveChannel.ts
+++ b/src/hooks/useJoinLeaveChannel.ts
@@ -20,8 +20,6 @@ export const useJoinLeaveChannels = (chatId: string) => {
     socket.emit(SOCKET.USERS);
     socket.on(SOCKET.USER_TO_CLIENT, (messages: { users: string[] }) => {
       if (!messages) return;
-      //setOnlineUsersIds(messages.users);
-      console.log('USER_TO_CLIENT', messages); // 현재방의 실시간유저, 방 랜더링 안되니까 당연히 안바뀜
     });
 
     serverSocket.emit(SOCKET.USERS_SERVER);
@@ -30,7 +28,6 @@ export const useJoinLeaveChannels = (chatId: string) => {
       (messages: { users: string[] }) => {
         if (!messages) return;
         setOnlineUsersIds(messages.users);
-        console.log('users-server-to-client', messages);
       },
     );
 
@@ -41,8 +38,16 @@ export const useJoinLeaveChannels = (chatId: string) => {
         setUserList(newMemberList);
       },
     );
+    socket.on(
+      SOCKET.JOIN,
+      async (messages: { users: string[]; joiners: string[] }) => {
+        const newMemberList = await getMemberData(messages.users);
+        setUserList(newMemberList);
+      },
+    );
 
     return () => {
+      socket.off(SOCKET.JOIN);
       socket.off(SOCKET.LEAVE);
       serverSocket.off(SOCKET.USERS_SERVER_TO_CLIENT);
     };

--- a/src/hooks/useJoinLeaveChannel.ts
+++ b/src/hooks/useJoinLeaveChannel.ts
@@ -17,11 +17,6 @@ export const useJoinLeaveChannels = (chatId: string) => {
     };
     getAllMemberList();
 
-    socket.emit(SOCKET.USERS);
-    socket.on(SOCKET.USER_TO_CLIENT, (messages: { users: string[] }) => {
-      if (!messages) return;
-    });
-
     serverSocket.emit(SOCKET.USERS_SERVER);
     serverSocket.on(
       SOCKET.USERS_SERVER_TO_CLIENT,

--- a/src/hooks/useMyChannels.ts
+++ b/src/hooks/useMyChannels.ts
@@ -1,11 +1,11 @@
-import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getMyChannels } from '../api/channel';
 import { Channel } from '../@types/channel';
+import { MY_CHANNELS } from '../constants/channel';
 
 export const useMyChannels = () => {
   return useQuery<Channel[]>({
-    queryKey: ['my-channels'],
+    queryKey: MY_CHANNELS,
     queryFn: getMyChannels,
   });
 };

--- a/src/hooks/useMyChannels.ts
+++ b/src/hooks/useMyChannels.ts
@@ -1,9 +1,10 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getMyChannels } from '../api/channel';
+import { Channel } from '../@types/channel';
 
 export const useMyChannels = () => {
-  return useQuery({
+  return useQuery<Channel[]>({
     queryKey: ['my-channels'],
     queryFn: getMyChannels,
   });


### PR DESCRIPTION
## ⛳️개요
유저목록 실시간 기능 일시 삭제 및 수정

## 📸 스크린샷

## ✍️ 구현 사항

- [ ] invite 시 toast 알림
- [ ] 채팅 추가 시 내채팅방 실시간 업데이트 mutation연동
- [ ] 유저목록에서 온라인 유저 표시 기능 일시 삭제 


## ⚡️ 고민한 점 질문거리

가현님께 제꺼 코드 넘겨드리려고 손 좀 봤는데,
제 쪽에서 소켓 연결이 계속 안되어서... 잘 되는지 모르겠어요.
소켓 연결만 되면 join/leave 유저목록은 실시간으로 잘 동작했습니다..!
우선 올려드린 코드가 저는 소켓만 계속 끊기고 axios나 api 오류는 없었어요
이거 더 수정해볼게요

!!
우선 아래 기능은 현재 pr에 없어요!
지금부터 손보려고 합니다

1. 초대된 사람에게만 toast 알람 (인증 확인으로 로그인한 정보 불러오는 거 맞더라고요, 슬랙방에 내용 있었어요)
2. 사이드바 고정